### PR TITLE
Fix to be able to use the pod with `use_frameworks!`

### DIFF
--- a/Source/Controllers/ESTabBarController.m
+++ b/Source/Controllers/ESTabBarController.m
@@ -40,7 +40,8 @@
 
 
 - (instancetype)initWithTabIcons:(NSArray *)tabIcons {
-    self = [self initWithNibName:@"ESTabBarController" bundle:nil];
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    self = [self initWithNibName:@"ESTabBarController" bundle:bundle];
     
     if (self != nil) {
         [self initializeWithTabIcons:tabIcons];


### PR DESCRIPTION
When initialising the view controller, now use `bundleForClass:` instead of the main bundle.

Fixes https://github.com/ezescaruli/ESTabBarController/issues/2.
