### PR TITLE
When the device is rotated, update the selection indicator leading.

### DIFF
--- a/Source/Controllers/ESTabBarController.m
+++ b/Source/Controllers/ESTabBarController.m
@@ -122,6 +122,21 @@
 }
 
 
+- (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation {
+    // When rotating, have to update the selection indicator leading to match
+    // the selected button x, that might have changed because of the rotation.
+    
+    CGFloat selectedButtonX = [self.buttons[self.selectedIndex] frame].origin.x;
+    
+    if (self.selectionIndicatorLeadingConstraint.constant != selectedButtonX) {
+        [UIView animateWithDuration:0.1 animations:^{
+            self.selectionIndicatorLeadingConstraint.constant = selectedButtonX;
+            [self.view layoutIfNeeded];
+        }];
+    }
+}
+
+
 #pragma mark - ESTabBarController
 
 


### PR DESCRIPTION
This is the PR that actually fixes https://github.com/ezescaruli/ESTabBarController/issues/13.
